### PR TITLE
Add an rdd.io package, with an operation to read an RDD from file.

### DIFF
--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/docs.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/docs.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.uncharted.sparkpipe.ops.core.rdd.io
+
+/**
+  * Stub object necessary due to [[https://issues.scala-lang.org/browse/SI-8124]]
+  *
+  * Documentation for `ops.core.rdd.io` can be found at [[software.uncharted.sparkpipe.ops.core.rdd.io]]
+  * @see [[software.uncharted.sparkpipe.ops.core.rdd.io]]
+  */
+protected[this] final object docs

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Uncharted Software Inc.
+ * Copyright 2015 Uncharted Software Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.uncharted.sparkpipe.ops.core.rdd
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
+
+/**
+  * Input/output operations for RDDs, based on the `SparkContext.textFile` API
+  */
+package object io {
+  /**
+    * Translates a SQLContext into a SparkContext, so that RDD operations can be called with either
+    *
+    * @param sqlc A SQLContext in which to run operations
+    * @return The spark context from which the SQL context was created
+    */
+  implicit def mutateContext (sqlc: SQLContext): SparkContext = sqlc.sparkContext
+
+  /**
+    * Reads a file into an RDD
+    *
+    * @param path The location of the source data
+    * @param sc The spark context in which to read the data
+    * @return An RDD of the text of the source data, line by line
+    */
+  def read(path: String)(sc: SparkContext): RDD[String] =
+    sc.textFile(path)
+}

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
@@ -24,6 +24,17 @@ import org.apache.spark.sql.SQLContext
   * Input/output operations for RDDs, based on the `SparkContext.textFile` API
   */
 package object io {
+  /** Simple text format, one line per record. */
+  val TEXT_FORMAT = "text"
+  /** An option key with which to specify the minimum number of partitions into which to read an input file */
+  val MIN_PARTITIONS = "minPartitions"
+  /** An option key with which to specify the compression codec with which to write text data */
+  val CODEC = "codec"
+  /** Codec value indicating that a text file should be written using the BZip2 codec */
+  val BZIP2_CODEC = "bzip2"
+  /** Codec value indicating that a text file should be written using the GZip codec */
+  val GZIP_CODEC = "gzip"
+
   /**
     * Translates a SQLContext into a SparkContext, so that RDD operations can be called with either
     *
@@ -44,12 +55,12 @@ package object io {
     */
   def read(
     path: String,
-    format: String = "text",
+    format: String = TEXT_FORMAT,
     options: Map[String, String] = Map[String, String]()
   )(sc: SparkContext): RDD[String] = {
-    assert("text" == format, "Only text format currently supported")
-    if (options.contains("minPartitions")) {
-      sc.textFile(path, options("minPartitions").trim.toInt)
+    assert(TEXT_FORMAT == format, "Only text format currently supported")
+    if (options.contains(MIN_PARTITIONS)) {
+      sc.textFile(path, options(MIN_PARTITIONS).trim.toInt)
     } else {
       sc.textFile(path)
     }
@@ -67,14 +78,14 @@ package object io {
     */
   def write[T] (
     path: String,
-    format: String = "text",
+    format: String = TEXT_FORMAT,
     options: Map[String, String] = Map[String, String]()
   )(input: RDD[T]): RDD[T] = {
-    assert("text" == format, "Only text format currently supported")
-    options.get("codec").map(_.trim.toLowerCase) match {
-      case Some("bzip2") =>
+    assert(TEXT_FORMAT == format, "Only text format currently supported")
+    options.get(CODEC).map(_.trim.toLowerCase) match {
+      case Some(BZIP2_CODEC) =>
         input.saveAsTextFile(path, classOf[BZip2Codec])
-      case Some("gzip") =>
+      case Some(GZIP_CODEC) =>
         input.saveAsTextFile(path, classOf[GzipCodec])
       case _ =>
         input.saveAsTextFile(path)

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/io/package.scala
@@ -44,6 +44,17 @@ package object io {
   implicit def mutateContext (sqlc: SQLContext): SparkContext = sqlc.sparkContext
 
   /**
+    * Traslate a function from a SparkContext into a function from a SQLContext, so that RDD operations
+    * can be run off a Pipe[SQLContext]
+    *
+    * @param fcn The SparkContext-based function
+    * @tparam T The return type of the function
+    * @return The same function, but working on a SQLContext.
+    */
+  implicit def mutateContextFcn[T](fcn: SparkContext => T): SQLContext => T =
+    input => fcn(input.sparkContext)
+
+  /**
     * Reads a file into an RDD
     *
     * @param path The location of the source data

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/io/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/io/PackageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Uncharted Software Inc.
+ * Copyright 2015 Uncharted Software Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/io/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/io/PackageSpec.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.SQLContext
 import org.mockito.Mockito._
 import org.scalatest.FunSpec
 import org.scalatest.mock.MockitoSugar
+import software.uncharted.sparkpipe.Pipe
 
 class PackageSpec extends FunSpec with MockitoSugar {
 
@@ -52,6 +53,23 @@ class PackageSpec extends FunSpec with MockitoSugar {
 
         // verify
         verify(mockSparkContext).textFile(path)
+      }
+
+      it("should work just as well with a Pipe[SQLContext] as with a Pipe[SparkContext]") {
+        val mockSparkContext = mock[SparkContext]
+        val mockSQLContext = mock[SQLContext]
+        val path = Math.random().toString
+
+        // Mock the link between them
+        when(mockSQLContext.sparkContext).thenReturn(mockSparkContext)
+
+        // Simple function to run
+        val fcn: SparkContext => SparkContext = sc => sc
+        val result = Pipe(mockSQLContext).to(fcn).run()
+
+        // verify
+        verify(mockSQLContext).sparkContext
+        assert(result === mockSparkContext)
       }
 
       it("should write a set number of partitions") {

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/io/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/io/PackageSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.uncharted.sparkpipe.ops.core.rdd.io
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+import org.mockito.Mockito._
+import org.scalatest.FunSpec
+import org.scalatest.mock.MockitoSugar
+
+class PackageSpec extends FunSpec with MockitoSugar {
+
+  describe("ops.core.rdd.io") {
+    describe("#read()") {
+      it("should load a file") {
+        val mockContext = mock[SparkContext]
+        val path = Math.random().toString
+
+        // test
+        read(path)(mockContext)
+
+        // verify
+        verify(mockContext).textFile(path)
+      }
+
+      it("should work just as well with a SQLContext as with a SparkContext") {
+        val mockSparkContext = mock[SparkContext]
+        val mockSQLContext = mock[SQLContext]
+        val path = Math.random().toString
+
+        // Mock the link between them
+        when(mockSQLContext.sparkContext).thenReturn(mockSparkContext)
+
+        // test
+        read(path)(mockSQLContext)
+
+        // verify
+        verify(mockSparkContext).textFile(path)
+      }
+    }
+  }
+}


### PR DESCRIPTION
I couldn't find a basic "load rdd" operation, so I thought I'd write one.

If there is one, please just ignore this.

Several comments:

- This only has a facade for textFile.  hadoopFile would probably also be good
- This only has load.  It should probably also have save (saveAsTextFile and saveAsHadoopDataset)

I didn't want to bother with all that, though, before talking to Sean.  I did want to go this far so I would know what I was talking about, but knowing that, I'll wait on more until I get PR comments.