### PR TITLE
Additional core operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@
  */
 
  group = 'software.uncharted.sparkpipe'
- version = '1.0.0'
+ version = '1.1.0-SNAPSHOT'
 
  project.ext {
    scalaBinaryVersion = '2.11'

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/package.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.uncharted.sparkpipe.ops.core.dataframe
+
+import org.apache.spark.sql.{DataFrame, Row}
+
+
+/*
+ * Common operations to aid in debugging dataframe processing in pipelines
+ */
+package object debug {
+
+  // $COVERAGE-OFF$
+  val defaultOutput = (s: String) => println(s)  // scalastyle:off regex
+  // $COVERAGE-ON$
+
+  /**
+    * Prints the number of rows in a dataframe.
+    * @param tag Tag to prepend to output.
+    * @param output Optional function to output debug message. Prints to console by default.
+    * @param data DataFrame to count.
+    * @return The input DataFrame.
+    */
+  def countDFRows (tag: String = "",
+                   output: (String) => Unit = defaultOutput)
+                  (data: DataFrame): DataFrame = {
+    output(s"[$tag] Number of rows: ${data.count}")
+    data
+  }
+
+  /**
+    * Prints the first n elements of a dataframe.
+    * @param rows Number of rows to print.
+    * @param tag Tag to prepend to output.
+    * @param output Optional function to output debug message. Prints to console by default.
+    * @param data Dataframe to extract rows from.
+    * @return The input dataFrame.
+    */
+  def takeDFRows (rows: Int, tag: String = "", output: (String) => Unit = defaultOutput)
+                 (data: DataFrame): DataFrame = {
+    output(s"[$tag] First $rows rows")
+    data.take(rows).zipWithIndex.foreach { case (text, row) => output(s"$row: $text") }
+    data
+  }
+
+  /**
+    * Applies a caller supplied debug function to the first n elements of a dataframe.
+    * @param rows Number of rows to process.
+    * @param fcn Function to apply to extracted rows.
+    * @param data Dataframe to extract rows from.
+    * @return The input dataframe.
+    */
+  def debugDFRows (rows: Int, fcn: Seq[Row] => Unit)(data: DataFrame): DataFrame = {
+    fcn(data.take(rows))
+    data
+  }
+}

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/package.scala
@@ -23,9 +23,7 @@ import org.apache.spark.sql.{DataFrame, Row}
  */
 package object debug {
 
-  // $COVERAGE-OFF$
   val defaultOutput = (s: String) => println(s)  // scalastyle:off regex
-  // $COVERAGE-ON$
 
   /**
     * Prints the number of rows in a dataframe.

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/package.scala
@@ -19,11 +19,10 @@ package software.uncharted.sparkpipe.ops.core
 import software.uncharted.sparkpipe.Pipe
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{SparkSession, DataFrame, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.udf
-import org.apache.spark.sql.types.DataType
-import scala.reflect.runtime.universe.{TypeTag, typeTag}
+import scala.reflect.runtime.universe.{TypeTag}
 
 /**
  * Common operations for manipulating dataframes

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/package.scala
@@ -255,4 +255,16 @@ package object dataframe {
     }).toSeq
     input.selectExpr(exprs:_*)
   }
+
+  /**
+    * Inner join two data frames on the specified columns.
+    * @param leftColumn The join ID column of the first data frame
+    * @param rightColumn The join ID column of the second data frame
+    * @param leftInput The first data frame
+    * @param rightInput The second data frame
+    * @return The joined data frames
+    */
+  def joinDataFrames(leftColumn: String, rightColumn: String)(leftInput: DataFrame, rightInput: DataFrame): DataFrame = {
+    leftInput.join(rightInput, leftInput(leftColumn) === rightInput(rightColumn))
+  }
 }

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/temporal/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/dataframe/temporal/package.scala
@@ -16,13 +16,11 @@
 
 package software.uncharted.sparkpipe.ops.core.dataframe
 
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{SparkSession, DataFrame, Row, Column}
-import org.apache.spark.sql.functions.{udf, callUDF}
-import org.apache.spark.sql.types.{DataType, TimestampType, IntegerType}
+import org.apache.spark.sql.{DataFrame, Column}
+import org.apache.spark.sql.functions.udf
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
-import java.util.{Calendar, Date, GregorianCalendar}
+import java.util.{Date, GregorianCalendar}
 
 /**
  * Common pipeline operations for dealing with temporal data
@@ -96,7 +94,7 @@ package object temporal {
    * @return Transformed pipeline data with the new time field column.
    */
   def parseDate(stringDateCol: String, dateCol: String, format: String)(input: DataFrame): DataFrame = {
-    val formatter = new SimpleDateFormat(format);
+    val formatter = new SimpleDateFormat(format)
     val fieldExtractor: String => Timestamp = i => {
       val date = formatter.parse(i)
       new Timestamp(date.getTime)

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/package.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.uncharted.sparkpipe.ops.core.rdd
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+
+
+/*
+ * Common operations to aid in debugging RDD processing in pipelines
+ */
+package object debug {
+  // $COVERAGE-OFF$
+  val defaultOutput = (s: String) => println(s) // scalastyle:off regex
+  // $COVERAGE-ON$
+
+  /**
+    * Prints the number of rows in an RDD.
+    * @param tag Tag to prepend to output.
+    * @param output Optional function to output debug message. Prints to console by default.
+    * @param rdd RDD to count.
+    * @return The input RDD.
+    */
+  def countRDDRows[T] (tag: String = "",
+                   output: (String) => Unit = defaultOutput)
+                  (rdd: RDD[T]): RDD[T] = {
+    output(s"[$tag] Number of rows: ${rdd.count}")
+    rdd
+  }
+
+  /**
+    * Prints the first n elements of an RDD.
+    * @param rows Number of rows to print.
+    * @param tag Tag to prepend to output.
+    * @param output Optional function to output debug message. Prints to console by default.
+    * @param rdd RDD to extract rows from.
+    * @return The input RDD.
+    */
+  def takeRDDRows[T](rows: Int, tag: String = "", output: (String) => Unit = defaultOutput)
+                 (rdd: RDD[T]): RDD[T] = {
+    output(s"[$tag] First $rows rows")
+    rdd.take(rows).zipWithIndex.foreach { case (text, row) => output(s"$row: $text") }
+    rdd
+  }
+
+  /**
+    * Applies a caller supplied debug function to the first n elements of an RDD.
+    * @param rows Number of rows to process.
+    * @param fcn Function to apply to extracted rows.
+    * @param rdd RDD to extract rows from.
+    * @return The input RDD.
+    */
+  def debugRDDRows[T] (rows: Int, fcn: Seq[T]=> Unit)(rdd: RDD[T]): RDD[T] = {
+    fcn(rdd.take(rows))
+    rdd
+  }
+}

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/package.scala
@@ -21,9 +21,8 @@ import org.apache.spark.rdd.RDD
  * Common operations to aid in debugging RDD processing in pipelines
  */
 package object debug {
-  // $COVERAGE-OFF$
+
   val defaultOutput = (s: String) => println(s) // scalastyle:off regex
-  // $COVERAGE-ON$
 
   /**
     * Prints the number of rows in an RDD.

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/package.scala
@@ -16,8 +16,6 @@
 package software.uncharted.sparkpipe.ops.core.rdd
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
-
 
 /*
  * Common operations to aid in debugging RDD processing in pipelines

--- a/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/text/package.scala
+++ b/src/main/scala/software/uncharted/sparkpipe/ops/core/rdd/text/package.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.uncharted.sparkpipe.ops.core.rdd
+
+import org.apache.spark.rdd.RDD
+
+package object text {
+
+  /**
+    * Filter an input string RDD to only those elements that match (or don't match) a given regular expression
+    *
+    * @param regexStr The regular expression to match
+    * @param exclude If true, filter matching entries out of the RDD; if false, filter out non-matching entries
+    * @param input The input data
+    * @return A new RDD containing the input data filtered as above.
+    */
+  def regexFilter (regexStr: String, exclude: Boolean = false)(input: RDD[String]): RDD[String] = {
+    val regex = regexStr.r
+    input.filter {
+      case regex(_*) => if (exclude) false else true
+      case _ => if (exclude) true else false
+    }
+  }
+}

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/PackageSpec.scala
@@ -17,15 +17,12 @@
 package software.uncharted.sparkpipe.ops.core.dataframe
 
 import org.scalatest._
-import org.apache.spark.storage.StorageLevel
 import software.uncharted.sparkpipe.Spark
 import software.uncharted.sparkpipe.ops.core.rdd.toDF
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.sum
-import org.apache.spark.sql.types._
 import org.scalatest.mock.MockitoSugar
-import org.mockito.Matchers._
 import org.mockito.Mockito._
 
 class PackageSpec extends FunSpec with MockitoSugar {

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/PackageSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.uncharted.sparkpipe.ops.core.dataframe.debug
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{ArrayType, StringType}
+import org.scalatest._
+import software.uncharted.sparkpipe.{Pipe, Spark}
+import software.uncharted.sparkpipe.ops.core.rdd.toDF
+
+import scala.collection.mutable.IndexedSeq
+
+class PackageSpec extends FunSpec {
+  describe("ops.core.dataframe.debug") {
+    val rdd = Spark.sc.parallelize(Seq((1, "alpha"), (2, "bravo"), (3, "charlie")))
+    val df = toDF(Spark.sparkSession)(rdd)
+
+    describe("#countDFRows()") {
+      it("should output a formatted count message using the supplied output function") {
+        var output = ""
+        countDFRows("test", (s: String) => output += s)(df)
+        assertResult("[test] Number of rows: 3")(output)
+      }
+    }
+
+    describe("#takeDFRows()") {
+      it("should output a list of the first N rows of the dataframe") {
+        var output = ""
+        takeDFRows(2, "test", (s: String) => output += s)(df)
+        assertResult("[test] First 2 rows0: [1,alpha]1: [2,bravo]")(output)
+      }
+    }
+
+    describe("#debugDFRows()") {
+      it("should apply a function to the first N rows of the dataframe") {
+        var output = Seq[Row]()
+        debugDFRows(2, (s: Seq[Row]) => output = s)(df)
+        assertResult(2)(output.length)
+        assertResult(output)(df.collect().slice(0, 2).toSeq)
+      }
+    }
+  }
+}

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/debug/PackageSpec.scala
@@ -16,24 +16,31 @@
 
 package software.uncharted.sparkpipe.ops.core.dataframe.debug
 
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{ArrayType, StringType}
-import org.scalatest._
-import software.uncharted.sparkpipe.{Pipe, Spark}
-import software.uncharted.sparkpipe.ops.core.rdd.toDF
+import java.io.ByteArrayOutputStream
 
-import scala.collection.mutable.IndexedSeq
+import org.apache.spark.sql.Row
+import org.scalatest._
+import software.uncharted.sparkpipe.Spark
+import software.uncharted.sparkpipe.ops.core.rdd.toDF
 
 class PackageSpec extends FunSpec {
   describe("ops.core.dataframe.debug") {
     val rdd = Spark.sc.parallelize(Seq((1, "alpha"), (2, "bravo"), (3, "charlie")))
     val df = toDF(Spark.sparkSession)(rdd)
 
-    describe("#countDFRows()") {
+   describe("#countDFRows()") {
       it("should output a formatted count message using the supplied output function") {
         var output = ""
         countDFRows("test", (s: String) => output += s)(df)
         assertResult("[test] Number of rows: 3")(output)
+      }
+
+      it("should output a formatted count message to std out when no output function is supplied") {
+        val bos = new ByteArrayOutputStream()
+        Console.withOut(bos) {
+          countDFRows("test")(df)
+        }
+        assertResult("[test] Number of rows: 3\n")(bos.toString)
       }
     }
 

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/io/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/io/PackageSpec.scala
@@ -17,8 +17,7 @@
 package software.uncharted.sparkpipe.ops.core.dataframe.io
 
 import org.scalatest._
-import software.uncharted.sparkpipe.Spark
-import org.apache.spark.sql.{SparkSession, DataFrame, DataFrameReader, DataFrameWriter}
+import org.apache.spark.sql.{SparkSession, DataFrameReader}
 import org.apache.spark.sql.types.{StructType, StructField, IntegerType}
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Matchers._

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/temporal/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/temporal/PackageSpec.scala
@@ -17,11 +17,8 @@
 package software.uncharted.sparkpipe.ops.core.dataframe.temporal
 
 import org.scalatest._
-import org.apache.spark.storage.StorageLevel
 import software.uncharted.sparkpipe.Spark
 import software.uncharted.sparkpipe.ops.core.rdd.toDF
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row}
 
 import java.text.SimpleDateFormat
 import java.sql.Timestamp

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/text/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/text/PackageSpec.scala
@@ -20,9 +20,7 @@ import org.scalatest._
 import software.uncharted.sparkpipe.Spark
 import software.uncharted.sparkpipe.Pipe
 import software.uncharted.sparkpipe.ops.core.rdd.toDF
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types.{IntegerType, StringType, ArrayType}
+import org.apache.spark.sql.types.{StringType, ArrayType}
 
 import scala.collection.mutable.IndexedSeq
 

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/text/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/text/PackageSpec.scala
@@ -175,5 +175,53 @@ class PackageSpec extends FunSpec {
         assert(result.getOrElse("amet", 0) == 1)
       }
     }
+
+    describe("includeRowTermFilter()") {
+      it("should produce a DataFrame that contains only rows that had at least one word in the term list") {
+        val result = Pipe(df)
+          .to(includeRowTermFilter("_2", Seq("sit", "amet", "Lorem"), caseSensitive = true))
+          .to(_.collect().map(s => s(1)).toSet)
+          .run()
+        assertResult(Set("lorem ipsum dolor sit", "lorem ipsum dolor sit amet lorem"))(result)
+      }
+      it("should produce a DataFrame that contains only rows that had at least one word in the term list ignoring case") {
+        val result = Pipe(df)
+          .to(includeRowTermFilter("_2", Seq("SIT", "aMet")))
+          .to(_.collect().map(s => s(1)).toSet)
+          .run()
+        assertResult(Set("lorem ipsum dolor sit", "lorem ipsum dolor sit amet lorem"))(result)
+      }
+      it("should produce a DataFrame that contains only rows that match the supplied regex") {
+        val result = Pipe(df)
+          .to(includeRowTermFilter("_2", "dolor sit".r))
+          .to(_.collect().map(s => s(1)).toSet)
+          .run()
+        assertResult(Set("lorem ipsum dolor sit", "lorem ipsum dolor sit amet lorem"))(result)
+      }
+    }
+
+   describe("stopRowTermFilter()") {
+      it("should produce a DataFrame that contains only rows that had at least one word in the term list") {
+        val result = Pipe(df)
+          .to(stopRowTermFilter("_2", Seq("sit", "amet", "Lorem"), caseSensitive = true))
+          .to(_.collect().map(s => s(1)).toSet)
+          .run()
+        assertResult(Set("lorem ipsum", "lorem ipsum dolor", null))(result)
+      }
+      it("should produce a DataFrame that contains only rows that had at least one word in the term list ignoring case") {
+        val result = Pipe(df)
+          .to(stopRowTermFilter("_2", Seq("SIT", "aMet")))
+          .to(_.collect().map(s => s(1)).toSet)
+          .run()
+        assertResult(Set("lorem ipsum", "lorem ipsum dolor", null))(result)
+      }
+      it("should produce a DataFrame that contains only rows that match the supplied regex") {
+        val result = Pipe(df)
+          .to(stopRowTermFilter("_2", "dolor sit".r))
+          .to(_.collect().map(s => s(1)).toSet)
+          .run()
+        assertResult(Set("lorem ipsum", "lorem ipsum dolor", null))(result)
+      }
+    }
   }
 }

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/text/util/UniqueTermAccumulatorSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/dataframe/text/util/UniqueTermAccumulatorSpec.scala
@@ -17,7 +17,6 @@
 package software.uncharted.sparkpipe.ops.core.dataframe.text.util
 
 import org.scalatest._
-import software.uncharted.sparkpipe.Spark
 
 class UniqueTermAccumulatorSpec extends FunSpec {
   describe("ops.core.dataframe.text.util.UniqueTermAccumulator") {

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/ml/pipeline/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/ml/pipeline/PackageSpec.scala
@@ -17,18 +17,14 @@
 package software.uncharted.sparkpipe.ops.core.ml.pipeline
 
 import org.scalatest._
-import org.apache.spark.SparkContext
 import software.uncharted.sparkpipe.Spark
-import org.apache.spark.sql.DataFrame
 import org.scalatest.mock.MockitoSugar
-import org.apache.spark.mllib.linalg.{Vector, Vectors}
-import org.mockito.Matchers._
+import org.apache.spark.mllib.linalg.Vectors
 import org.mockito.Mockito._
 import org.apache.spark.ml.Pipeline
-import org.apache.spark.ml.util.MLReader
 import org.apache.spark.ml.classification.LogisticRegression
 import org.apache.spark.ml.feature.{HashingTF, Tokenizer}
-import org.apache.spark.ml.{Pipeline => MLPipeline, PipelineStage => MLPipelineStage, PipelineModel => MLPipelineModel}
+import org.apache.spark.ml.{Pipeline => MLPipeline, PipelineModel => MLPipelineModel}
 
 
 class PackageSpec extends FunSpec with MockitoSugar {

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/PackageSpec.scala
@@ -16,7 +16,6 @@
 
 package software.uncharted.sparkpipe.ops.core.rdd.debug
 
-import org.apache.spark.sql.Row
 import org.scalatest._
 import software.uncharted.sparkpipe.Spark
 

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/PackageSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.uncharted.sparkpipe.ops.core.rdd.debug
+
+import org.apache.spark.sql.Row
+import org.scalatest._
+import software.uncharted.sparkpipe.Spark
+
+class PackageSpec extends FunSpec {
+  describe("ops.core.rdd.debug") {
+    val rdd = Spark.sc.parallelize(Seq((1, "alpha"), (2, "bravo"), (3, "charlie")))
+
+    describe("#countRDDRows()") {
+      it("should output a formatted count message using the supplied output function") {
+        var output = ""
+        countRDDRows("test", (s: String) => output += s)(rdd)
+        assertResult("[test] Number of rows: 3")(output)
+      }
+    }
+
+    describe("#takeRDDRows()") {
+      it("should output a list of the first N rows of the rdd") {
+        var output = ""
+        takeRDDRows(2, "test", (s: String) => output += s)(rdd)
+        assertResult("[test] First 2 rows0: (1,alpha)1: (2,bravo)")(output)
+      }
+    }
+
+    describe("#debugRDDRows()") {
+      it("should apply a function to the first N rows of the rdd") {
+        var output = Seq[(Int, String)]()
+        debugRDDRows(2, (s: Seq[(Int, String)]) => output = s)(rdd)
+        assertResult(2)(output.length)
+        assertResult(output)(rdd.collect().slice(0, 2).toSeq)
+      }
+    }
+  }
+}

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/debug/PackageSpec.scala
@@ -16,6 +16,8 @@
 
 package software.uncharted.sparkpipe.ops.core.rdd.debug
 
+import java.io.ByteArrayOutputStream
+
 import org.scalatest._
 import software.uncharted.sparkpipe.Spark
 
@@ -28,6 +30,14 @@ class PackageSpec extends FunSpec {
         var output = ""
         countRDDRows("test", (s: String) => output += s)(rdd)
         assertResult("[test] Number of rows: 3")(output)
+      }
+
+      it("should output a formatted count message to std out when no output function is supplied") {
+        val bos = new ByteArrayOutputStream()
+        Console.withOut(bos) {
+          countRDDRows("test")(rdd)
+        }
+        assertResult("[test] Number of rows: 3\n")(bos.toString)
       }
     }
 

--- a/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/text/PackageSpec.scala
+++ b/src/test/scala/software/uncharted/sparkpipe/ops/core/rdd/text/PackageSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.uncharted.sparkpipe.ops.core.rdd.text
+
+import org.scalatest.FunSpec
+import software.uncharted.sparkpipe.Spark
+
+class PackageSpec extends FunSpec {
+
+  describe("ops.core.rdd.text") {
+    describe("#regexFilter()") {
+      it("Should pass through only strings that match the given regular expression") {
+        val data = Spark.sc.parallelize(Seq("abc def ghi", "abc d e f ghi", "the def quick", "def ghi", "abc def"))
+        assertResult(List("abc def ghi", "the def quick", "def ghi"))(regexFilter(".*def.+")(data).collect.toList)
+        assertResult(List("abc d e f ghi", "def ghi"))(regexFilter(".+def.*", true)(data).collect.toList)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a few new operations implemented by other projects using sparkpipe:
* RDD and DataFrame pipeline debugging
* General n-dimensional numeric range filtering
* String RDD regex filtering
* Dataframe regex + term list row filtering
* Dataframe inner join

These may not all fit in the scope of the core, and can be left in the source projects as required.